### PR TITLE
GoPiGo3 Runtime: convert URML LFU frame to GoPiGo3 RFD frame in orbit() and turn_degrees()

### DIFF
--- a/examples/gopigo3/gopigo3-report.txt
+++ b/examples/gopigo3/gopigo3-report.txt
@@ -12,9 +12,9 @@ robot: gopigo3_basic   drive_type: differential   max drive: 2.0 m
 [VALID] short patrol: turn, drive, turn, drive, announce, report
    executed 6 steps, success=True
    wheel + speech calls, in order:
-     turn_by      -> easygopigo3.turn_degrees(90.0)
-     drive_by     -> easygopigo3.drive_cm(50.0)
      turn_by      -> easygopigo3.turn_degrees(-90.0)
+     drive_by     -> easygopigo3.drive_cm(50.0)
+     turn_by      -> easygopigo3.turn_degrees(90.0)
      drive_by     -> easygopigo3.drive_cm(50.0)
      emit_speech  -> espeak 'Patrol complete'
      emit_report

--- a/examples/gopigo3/gopigo3_adapter.py
+++ b/examples/gopigo3/gopigo3_adapter.py
@@ -189,18 +189,20 @@ class GoPiGo3Adapter:
             # the arc radius is distance / arc-in-radians. easygopigo3.orbit takes
             # (degrees, radius_cm), a radius, not a path length.
             radius_cm = abs(cm) / abs(math.radians(arc))
-            arc *= -1   # Convert from URML LFU to GoPiGo3 RFD frame
-            gpg.orbit(arc, radius_cm)
-            hw = f"orbit({arc:.1f}, {radius_cm:.1f})"
+            # URML FLU (+CCW) -> GoPiGo3 RFD (+CW): negate at the hardware
+            # boundary only, so call_log stays in the URML frame (#591, #598).
+            gpg.orbit(-arc, radius_cm)
+            hw = f"orbit({-arc:.1f}, {radius_cm:.1f})"
         self.call_log.append({"method": "drive_by", "distance": distance, "arc": arc, "hw": hw})
         return NavigationResult(success=True, final_pose=None, frame="gopigo3")
 
     def turn_by(self, *, angle: float) -> NavigationResult:
         """Rotate in place by a signed angle (degrees, + counterclockwise)."""
         gpg = self._robot()
-        angle *= -1   # Convert from URML LFU to GoPiGo3 RFD frame
-        gpg.turn_degrees(angle)
-        self.call_log.append({"method": "turn_by", "angle": angle, "hw": f"turn_degrees({angle:.1f})"})
+        # URML FLU (+CCW) -> GoPiGo3 RFD (+CW): negate at the hardware
+        # boundary only, so call_log stays in the URML frame (#591, #598).
+        gpg.turn_degrees(-angle)
+        self.call_log.append({"method": "turn_by", "angle": angle, "hw": f"turn_degrees({-angle:.1f})"})
         return NavigationResult(success=True, final_pose=None, frame="gopigo3")
 
     # ------------------------------------------------------------------

--- a/examples/gopigo3/gopigo3_adapter.py
+++ b/examples/gopigo3/gopigo3_adapter.py
@@ -189,7 +189,7 @@ class GoPiGo3Adapter:
             # the arc radius is distance / arc-in-radians. easygopigo3.orbit takes
             # (degrees, radius_cm), a radius, not a path length.
             radius_cm = abs(cm) / abs(math.radians(arc))
-            arc += -1   # Convert from URML LFU to GoPiGo3 RFD frame
+            arc *= -1   # Convert from URML LFU to GoPiGo3 RFD frame
             gpg.orbit(arc, radius_cm)
             hw = f"orbit({arc:.1f}, {radius_cm:.1f})"
         self.call_log.append({"method": "drive_by", "distance": distance, "arc": arc, "hw": hw})
@@ -198,7 +198,7 @@ class GoPiGo3Adapter:
     def turn_by(self, *, angle: float) -> NavigationResult:
         """Rotate in place by a signed angle (degrees, + counterclockwise)."""
         gpg = self._robot()
-        angle += -1   # Convert from URML LFU to GoPiGo3 RFD frame
+        angle *= -1   # Convert from URML LFU to GoPiGo3 RFD frame
         gpg.turn_degrees(angle)
         self.call_log.append({"method": "turn_by", "angle": angle, "hw": f"turn_degrees({angle:.1f})"})
         return NavigationResult(success=True, final_pose=None, frame="gopigo3")

--- a/examples/gopigo3/gopigo3_adapter.py
+++ b/examples/gopigo3/gopigo3_adapter.py
@@ -189,6 +189,7 @@ class GoPiGo3Adapter:
             # the arc radius is distance / arc-in-radians. easygopigo3.orbit takes
             # (degrees, radius_cm), a radius, not a path length.
             radius_cm = abs(cm) / abs(math.radians(arc))
+            arc += -1   # Convert from URML LFU to GoPiGo3 RFD frame
             gpg.orbit(arc, radius_cm)
             hw = f"orbit({arc:.1f}, {radius_cm:.1f})"
         self.call_log.append({"method": "drive_by", "distance": distance, "arc": arc, "hw": hw})
@@ -197,6 +198,7 @@ class GoPiGo3Adapter:
     def turn_by(self, *, angle: float) -> NavigationResult:
         """Rotate in place by a signed angle (degrees, + counterclockwise)."""
         gpg = self._robot()
+        angle += -1   # Convert from URML LFU to GoPiGo3 RFD frame
         gpg.turn_degrees(angle)
         self.call_log.append({"method": "turn_by", "angle": angle, "hw": f"turn_degrees({angle:.1f})"})
         return NavigationResult(success=True, final_pose=None, frame="gopigo3")

--- a/reference/validator/tests/test_gopigo3_example.py
+++ b/reference/validator/tests/test_gopigo3_example.py
@@ -51,10 +51,12 @@ def test_validated_intent_lowers_to_wheel_calls() -> None:
     # Both programs validate before actuating.
     assert "[VALID] announce, then drive 1 m" in report
     assert "[REJECTED]" not in report
-    # `drive` lowered to the easygopigo3 call; `speak` to espeak.
+    # `drive` lowered to the easygopigo3 call; `speak` to espeak. A URML +90
+    # (left, FLU/+CCW) turn lowers to turn_degrees(-90) in GoPiGo3's RFD
+    # frame (#591, #598).
     assert "drive_by     -> easygopigo3.drive_cm(100.0)" in report
     assert "emit_speech  -> espeak 'Driving forward 1 meter'" in report
-    assert "turn_by      -> easygopigo3.turn_degrees(90.0)" in report
+    assert "turn_by      -> easygopigo3.turn_degrees(-90.0)" in report
 
 
 def test_arc_drive_lowers_distance_to_orbit_radius() -> None:
@@ -62,8 +64,9 @@ def test_arc_drive_lowers_distance_to_orbit_radius() -> None:
     radius is distance / arc-in-radians, not distance itself (Discussion #572).
 
     "Orbit 180 degrees with a 5 cm radius" is a 0.157 m arc (pi x 0.05), and must
-    lower to easygopigo3.orbit(180, 5.0). Regression for the bug where `distance`
-    was passed straight in as the orbit radius.
+    lower to easygopigo3.orbit(-180, 5.0) (the sign flip is the FLU->RFD frame
+    conversion, #591/#598). Regression for the bug where `distance` was passed
+    straight in as the orbit radius.
     """
     if str(EX) not in sys.path:
         sys.path.insert(0, str(EX))
@@ -79,8 +82,37 @@ def test_arc_drive_lowers_distance_to_orbit_radius() -> None:
     adapter = GoPiGo3Adapter()
     adapter._gpg = _FakeBot()  # bypass the lazy easygopigo3 import (hermetic)
     adapter.drive_by(distance=math.pi * 0.05, arc=180.0)  # 5 cm radius, half circle
-    assert adapter._gpg.calls == [(180.0, 5.0)]
-    assert adapter.call_log[-1]["hw"] == "orbit(180.0, 5.0)"
+    # The hardware call carries the RFD-frame (negated) arc; call_log stays URML-frame.
+    assert adapter._gpg.calls == [(-180.0, 5.0)]
+    assert adapter.call_log[-1]["hw"] == "orbit(-180.0, 5.0)"
+    assert adapter.call_log[-1]["arc"] == 180.0
+
+
+def test_frame_conversion_flu_to_rfd() -> None:
+    """#591/#598: URML speaks FLU (+CCW = left); easygopigo3 speaks RFD (+CW = right).
+
+    The adapter negates at the hardware boundary and nowhere else: a URML
+    left turn (+90) must reach the wheels as turn_degrees(-90), while the
+    audit trail keeps the URML-frame value the validator approved.
+    """
+    if str(EX) not in sys.path:
+        sys.path.insert(0, str(EX))
+    from gopigo3_adapter import GoPiGo3Adapter
+
+    class _FakeBot:
+        def __init__(self) -> None:
+            self.turns: list[float] = []
+
+        def turn_degrees(self, deg: float) -> None:
+            self.turns.append(round(deg, 1))
+
+    adapter = GoPiGo3Adapter()
+    adapter._gpg = _FakeBot()
+    adapter.turn_by(angle=90.0)   # URML: turn left
+    adapter.turn_by(angle=-45.0)  # URML: turn right
+    assert adapter._gpg.turns == [-90.0, 45.0]
+    assert [c["angle"] for c in adapter.call_log] == [90.0, -45.0]
+    assert adapter.call_log[0]["hw"] == "turn_degrees(-90.0)"
 
 
 def test_radius_form_lowers_to_orbit_without_arithmetic(tmp_path) -> None:
@@ -89,8 +121,8 @@ def test_radius_form_lowers_to_orbit_without_arithmetic(tmp_path) -> None:
     "Orbit 180 degrees with a 5 cm radius" is written `drive: {radius: 0.05, arc:
     180}` with no arc-length arithmetic. The runtime resolves it to the arc length
     (0.05 x pi) and the adapter recovers the 5 cm radius, so it lowers to
-    easygopigo3.orbit(180, 5.0). Under the arc-length form a model that doubled the
-    arithmetic drove a 10 cm arc; the radius form removes that failure mode.
+    easygopigo3.orbit(-180, 5.0) (RFD frame). Under the arc-length form a model that
+    doubled the arithmetic drove a 10 cm arc; the radius form removes that failure mode.
     """
     gen = _load_gen()
     prog = tmp_path / "orbit.urml.yaml"
@@ -104,7 +136,7 @@ def test_radius_form_lowers_to_orbit_without_arithmetic(tmp_path) -> None:
     )
     report = gen.run_program_file(str(prog), prefer_real=False)
     assert "[VALID] program file: orbit.urml.yaml" in report
-    assert "drive_by     -> easygopigo3.orbit(180.0, 5.0)" in report
+    assert "drive_by     -> easygopigo3.orbit(-180.0, 5.0)" in report
     assert "Dry run" in report
 
 


### PR DESCRIPTION

Per Issue https://github.com/URML-MARS/URML/issues/598 
and Issue https://github.com/URML-MARS/URML/issues/591


## What changed and why

gopigo3_adapter.py - the GoPiGo3 Runtime must convert the URML Left-Front-Up frame  
to the GoPiGo3 Right-Front-Down frame

Calls to easygopigo3.orbit(arc,radius_cm) and .turn_degrees(angle) have negated arc and angle

## Linked RFC

- Not required — this is implementation  only, no spec change.

## How it was tested
Using test_orbit_turn.urml.yaml containing:
```
(gopigo3) ubuntu@U26LDave:~/Fork_URML_For_GoPiGo3/examples/gopigo3$ more test_orbit_turn.urml.yaml 
profile: educational
behavior:
  type: sequence
  on_error: abort_and_report
  steps:
  - drive:
      distance: 0.25
      speed: 0.15
  - turn:
      angle: 360
  - drive:
      radius: 0.1
      arc: 180

```


Dry Run: 
```
(gopigo3) ubuntu@U26LDave:~/Fork_URML_For_GoPiGo3/examples/gopigo3$ python3 run_gopigo3.py -f test_orbit_turn.urml.yaml 
[gopigo3 example] gopigo3 example, running on urml-validator 0.2.0, urml-ros2-runtime 0.2.0
[gopigo3 example] backend: fake (dry run, no movement)
URML on a basic GoPiGo3 - running test_orbit_turn.urml.yaml (Discussion #523).
gopigo3 example, running on urml-validator 0.2.0, urml-ros2-runtime 0.2.0
robot: gopigo3_basic   drive_type: differential   max drive: 2.0 m

[VALID] program file: test_orbit_turn.urml.yaml
   executed 3 steps, success=True
   wheel + speech calls, in order:
     drive_by     -> easygopigo3.drive_cm(25.0)
     turn_by      -> easygopigo3.turn_degrees(-360.0)
     drive_by     -> easygopigo3.orbit(-180.0, 10.0)

Dry run: validated and planned, not actuated. Pass --execute (without -m) to drive the robot.
```
And with --execute:
```
(gopigo3) ubuntu@U26LDave:~/Fork_URML_For_GoPiGo3/examples/gopigo3$ python3 run_gopigo3.py -f test_orbit_turn.urml.yaml --execute
[gopigo3 example] gopigo3 example, running on urml-validator 0.2.0, urml-ros2-runtime 0.2.0
[gopigo3 example] --execute: this WILL move a connected GoPiGo3. Clear space around the robot.
[gopigo3 example] backend: real (executing on hardware)
URML on a basic GoPiGo3 - running test_orbit_turn.urml.yaml (Discussion #523).
gopigo3 example, running on urml-validator 0.2.0, urml-ros2-runtime 0.2.0
robot: gopigo3_basic   drive_type: differential   max drive: 2.0 m

[VALID] program file: test_orbit_turn.urml.yaml
   executed 3 steps, success=True
   wheel + speech calls, in order:
     drive_by     -> easygopigo3.drive_cm(25.0)
     turn_by      -> easygopigo3.turn_degrees(-360.0)
     drive_by     -> easygopigo3.orbit(-180.0, 10.0)

```
Turned and orbited in a ccw direction per the URML specification

(Albeit the turn_by spin default speed is uncomfortably fast...)

## Rollback plan

revert gopigo3_adapter.py

## Checklist

- [x] Commits are **DCO-signed** (`git commit -s`). See [`DCO`](../DCO) and [`CONTRIBUTING.md`](../CONTRIBUTING.md).
- [ ] Linked RFC is **Accepted** (or this PR does not change specification semantics).
- [ ] Tests added or updated for the change; existing tests pass.
- [ ] Conformance impact considered. If a primitive's contract changed, conformance tests are updated.
- [ ] Docs / READMEs / `CHANGELOG.md` updated.
- [ ] Substrate-neutrality acid test passes: anything touching Layer 2 can be cleanly implemented on a runtime with zero ROS dependencies.
- [ ] No content from outside the URML organization's canonical scope (civilian, consumer, educational, industrial, research) has been introduced.
